### PR TITLE
Safe for phpcs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,10 +12,6 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[*.{yml,yaml}]
-end_of_line = lf
-insert_final_newline = true
-charset = utf-8
-trim_trailing_whitespace = true
-indent_style = space
+[*.{yml,yaml,json,neon}]
 indent_size = 2
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .idea
 .phpunit.result.cache
 /vendor
-vendor-bin
 config/phpstan/phpstan.neon
 composer.lock
 node_modules
@@ -17,3 +16,7 @@ tmp/*
 !tmp/.keep
 pnpm-lock.yaml
 gha-creds-*.json
+
+/vendor-bin/**/vendor/
+/vendor-bin/**/composer.lock
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,19 +14,24 @@ RUN set -eux ; \
     $([ "$(apk --print-arch)" != "x86" ] && echo mercurial) \
     $([ "$(apk --print-arch)" != "armhf" ] && echo p7zip)
 
-# Install Composer and set up application
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
-RUN mkdir /coding-standard
-COPY . /coding-standard/
-
-ENV COMPOSER_ALLOW_SUPERUSER 1
-RUN echo 'memory_limit = 2G' >> /usr/local/etc/php/conf.d/memory-limit.ini
-RUN composer -d /coding-standard install --no-dev
-
+# Config Git
 RUN git config --global --add safe.directory /app
 RUN git config --global user.email "noone@rewe-digital.com" && \
     git config --global user.name "Coding-Standard container"
 
+# Allow more memory for php processes
+RUN echo 'memory_limit = 2G' >> /usr/local/etc/php/conf.d/memory-limit.ini
+RUN echo 'error_reporting = E_ALL & ~E_DEPRECATED' >> /usr/local/etc/php/conf.d/error-reporting.ini
+
+# Install Composer
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
+# Install Coding-Standard-Source
+RUN mkdir /coding-standard
+COPY . /coding-standard/
+WORKDIR /coding-standard/
+RUN composer install --no-dev --no-interaction --no-progress --optimize-autoloader
 WORKDIR /app/
 
 ENTRYPOINT [ "/coding-standard/src/bin/coding-standard" ]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ continuous integration tool of your choice. It searches your source code to
 find files to check with its static code analysis tools. Information about
 its usage can be found by calling it with -h option.
 
-## Installation (as intendet)
+## Installation (as intended)
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -5,40 +5,43 @@
 
 # ZooRoyal Coding Standard Source
 
-This repository holds the necessary sources to use and build the ZooRoyal 
-Coding Standard. 
+---
+
+This repository holds the necessary sources to use and build the ZooRoyal
+Coding Standard.
 
 It incorporates
-* [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer) 
+* [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer)
   and its configuration
 * [PHP Mess Detector](https://github.com/phpmd/phpmd) and its configuration
 * [PHP Copy Paste Detector](https://github.com/sebastianbergmann/phpcpd)
 * [PHP-Parallel-Lint](https://github.com/JakubOnderka/PHP-Parallel-Lint)
-* [PHPStan - PHP Static Analysis Tool](https://github.com/phpstan/phpstan) 
+* [PHPStan - PHP Static Analysis Tool](https://github.com/phpstan/phpstan)
   and its configuration
 * [ES-LINT](https://github.com/eslint/eslint) and its configuration
 * [STYLE-LINT](https://github.com/stylelint/stylelint) and its configuration
 
-In addition, there is a PHP script in src/bin to be used by a 
-continuous integration tool of your choice. It searches your source code to 
-find files to check with its static code analysis tools. Information about 
+In addition, there is a PHP script in src/bin to be used by a
+continuous integration tool of your choice. It searches your source code to
+find files to check with its static code analysis tools. Information about
 its usage can be found by calling it with -h option.
 
-# Installation
+## Installation (as intendet)
 
-## Docker
+### Docker
 
-The ZooRoyal Coding Standard is designed to be used as a docker isolated 
-application. Therefore, no installation is needed if you have a docker 
-daemon available on your system. 
-## Composer
+The ZooRoyal Coding Standard is designed to be used as a docker isolated
+application. Therefore, no installation is needed if you have a docker
+daemon available on your system.
+
+### Composer
 
 If ...
-* ... you don't feel comfortable with the docker user experience ... 
-* .. want to bind your source code to a certain version of the ZooRoyal 
+* ... you don't feel comfortable with the docker user experience ...
+* ... want to bind your source code to a certain version of the ZooRoyal
   Coding Standard ...
 
-... you find a ready made composer package at https://github.com/ZooRoyal/coding-standard
+... you find a ready-made composer package at https://github.com/ZooRoyal/coding-standard
 
 ```bash
 composer require --dev "zooroyal/coding-standard"
@@ -46,79 +49,122 @@ composer require --dev "zooroyal/coding-standard"
 
 It will still require you to have a docker daemon available on your system.
 
+The ZooRoyal Coding Standard application will be available under
+`vendor/bin/coding-standard`.
+
 ## Install from source (not recommended)
 
-### Composer from source
-
-If all else fails, you can install the ZooRoyal Coding Standard from this source 
-package. **Please be aware that this is not recommended**. There will be 
-tons of dependencies the rest of you project will have to comply with. They 
+If all else fails, you can install the ZooRoyal Coding Standard from this source
+package. **Please be aware that this is not recommended**. There will be
+tons of dependencies the rest of your project will have to comply with. They
 will be very specific and change as we see fit.
+
+#### Standalone
+
+If you want to use the ZooRoyal Coding Standard as a standalone application, you
+can use the following commands:
+
+```bash
+git clone git@github.com:ZooRoyal/coding-standard-source.git
+cd coding-standard-source
+composer install
+```
+
+The ZooRoyal Coding Standard application will be available under
+`src/bin/coding-standard`.
+
+#### As composer dependency
+
+To use the ZooRoyal Coding Standard as a composer dependency, you can
+require it via composer but this alone won't be enough. You will have to install
+the necessary tools as well. For this to happen, you can use the following
+process:
 
 ```bash
 composer require --dev "zooroyal/coding-standard-source"
 ```
 
-### Eslint and StyleLint
+Now you need to add the following lines to your composer.json:
 
-In case you want to use eslint and stylelint checks you have to install the packages from the package.json in the root folder of your project.
-
-### Local Installation
-
-You may install the packages locally in your project. For this to happen you need to follow the following  steps:
-
-1. `composer require --dev zooroyal/coding-standard`
-2. `npm install --save-dev vendor/zooroyal/coding-standard`
-
-#### Global Installation
-
-You may have installed eslint and stylelint globally in your system. If you want ZooRoyal Coding Standard to try to use them
- just make sure ZooRoyal Coding Standard is installed properly.
-
-```bash
-composer require --dev zooroyal/coding-standard-source
+```json
+{
+    [...]
+    "extra": {
+        [...]
+        "bamarni-bin": {
+            "bin-links": true,
+            "forward-command": true
+        }
+    }
+    [...]
+}
 ```
 
-### Update
-
-To update this package just run
+The final step is to install the necessary tools. This can be done by
+running the following command:
 
 ```bash
-composer update "zooroyal/coding-standard-source"
+cp -r vendor/zooroyal/coding-standard-source/vendor-bin .
+composer update
+# If you need Javascript support ...
+npm install --save-dev vendor/zooroyal/coding-standard-source
 ```
 
-# Usage ZooRoyal Coding Standard
+This will install the following tools in several directories under `vendor-bin`:
 
-Please keep in mind, that ZooRoyal Coding Standard can only check source 
+* [PHPStan](https://phpstan.org/) ([composer.json](./vendor-bin/phpstan/composer.json))
+* [PHP-Parallel-Lint](https://github.com/php-parallel-lint/PHP-Parallel-Lint)
+  ([composer.json](./vendor-bin/php-parallel-lint/composer.json))
+* [PHPCPD](https://packagist.org/packages/sebastian/phpcpd)
+  ([composer.json](./vendor-bin/phpcpd/composer.json))
+* [PHPMD](https://phpmd.org/)
+  ([composer.json](./vendor-bin/phpmd/composer.json))
+
+This tools will be installed in `node_modules`:
+* [EsLint](https://eslint.org/)
+  ([package.json](./package.json))
+* [StyleLint](https://stylelint.io/)
+  ([package.json](./package.json))
+
+The ZooRoyal Coding Standard application will be available under
+`vendor/bin/coding-standard`.
+
+## Usage ZooRoyal Coding Standard
+
+Please keep in mind, that ZooRoyal Coding Standard can only check source
 code which is a **git repository** as well as a **composer project**
 
-## Using the docker image directly
+### Using the docker image directly
 
 If you want to use the docker image directly, you can use the following command:
 
 ```bash
-docker run --rm -it -v $(pwd):/app zooroyal/coding-standard
+docker run --rm -t -v $(pwd):/app ghcr.io/zooroyal/coding-standard-source:latest <parameter>
 ```
 
-This will mount your current working directory as the root directory of the 
+This will mount your current working directory as the root directory of the
 source code you want to check.
 
 For your convenience, you can create an alias for this command:
 ```bash
-alias coding-standard="docker run --rm -it -v \$(pwd):/app zooroyal/coding-standard"
+alias coding-standard="docker run --rm -t -v $(pwd):/app ghcr.io/zooroyal/coding-standard-source:latest"
 ```
 
 To use a certain version of the coding-standard, just add the version tag to the image name:
 ```bash
-docker run --rm -it -v \$(pwd):/app zooroyal/coding-standard:4.0.1
+docker run --rm -t -v $(pwd):/app ghcr.io/zooroyal/coding-standard-source:4.0.0 <parameter>
 ```
 
-## Using one of the composer packages
+### Using one of the composer packages
 
-The composer package will install a script in your `vendor/bin` folder of 
-your composer project. This can be used to run the coding standard.
+The composer package will install a script in your `vendor/bin` folder of your composer project
+or `src/bin`  of the standalone installation folder. Use them to run the
+ZooRoyal Coding Standard.
 
-## Using the ZooRoyal Coding Standard
+The ZooRoyal Coding Standard application must be executed from the root of
+your project.
+
+### Using the ZooRoyal Coding Standard
 
 Run the command to get usage instructions.
 ```bash
@@ -142,7 +188,7 @@ Available commands:
   sca:stan                  Run PHPStan on PHP files.
 ```
 
-## Example `sca:all`
+### Example `sca:all`
 
 ```bash
 coding-standard sca:all -h
@@ -189,9 +235,9 @@ This command computes the diff to the branch origin/master and searches for all 
 
 For examples just have a look an the .travis.yml
 
-# Extend the Coding Standard
+## Extend the Coding Standard
 
-If you want to extend the ZooRoyal Coding Standard with your own tools there are two 
+If you want to extend the ZooRoyal Coding Standard with your own tools there are two
 tutorials available:
 
 * [How to add a new static code analysis tool](doc/howto/HowToAddANewTool.md)

--- a/composer.json
+++ b/composer.json
@@ -28,22 +28,13 @@
     "ext-json": "*",
     "ext-xml": "*",
     "composer-runtime-api": "^2.0",
+    "bamarni/composer-bin-plugin": "^1.8",
     "composer/semver": "^3.3",
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
     "nette/neon": "^3.3",
     "nikic/php-parser": "^4.15",
     "php-di/php-di": "^7.0.1",
-    "php-parallel-lint/php-console-highlighter": "^1.0.0",
-    "php-parallel-lint/php-parallel-lint": "^1.3.2",
     "phpcompatibility/php-compatibility": "^9.3",
-    "phpmd/phpmd": "^2.13.0",
-    "phpstan/extension-installer": "^1.2",
-    "phpstan/phpstan": "^1.10.13",
-    "phpstan/phpstan-doctrine": "^1.3.32",
-    "phpstan/phpstan-mockery": "^1.1.0",
-    "phpstan/phpstan-phpunit": "^1.3.3",
-    "phpstan/phpstan-symfony": "^1.2.20",
-    "sebastian/phpcpd": "^6.0.3",
     "slevomat/coding-standard": "^8.10.0",
     "squizlabs/php_codesniffer": "^3.7.2",
     "symfony/console": " ^6.2.8",
@@ -103,10 +94,15 @@
     "sort-packages": true,
     "process-timeout": 600,
     "allow-plugins": {
-      "phpstan/extension-installer": true,
       "dealerdirect/phpcodesniffer-composer-installer": true,
       "infection/extension-installer": true,
-      "mindplay/composer-locator": true
+      "bamarni/composer-bin-plugin": true
+    }
+  },
+  "extra": {
+    "bamarni-bin": {
+      "bin-links": true,
+      "forward-command": true
     }
   }
 }

--- a/config/phpstan/phpstan.neon.dist
+++ b/config/phpstan/phpstan.neon.dist
@@ -1,3 +1,4 @@
+
 parameters:
     level: 5
     parallel:

--- a/src/main/php/CommandLine/StaticCodeAnalysis/Generic/TerminalCommand/PhpVersion/VersionDecorator.php
+++ b/src/main/php/CommandLine/StaticCodeAnalysis/Generic/TerminalCommand/PhpVersion/VersionDecorator.php
@@ -50,20 +50,15 @@ class VersionDecorator extends TerminalCommandDecorator
             return;
         }
 
-        if ($this->cachedMinPhpVersion !== null) {
-            $terminalCommand->setPhpVersion($this->cachedMinPhpVersion);
-            return;
+        if ($this->cachedMinPhpVersion === null) {
+            $composerFiles = $this->gatherComposerFiles();
+            $this->cachedMinPhpVersion = $this->searchMinimalViablePhpVersion($composerFiles);
         }
 
-        $composerFiles = $this->gatherComposerFiles();
-        $minPhpVersion = $this->searchMinimalViablePhpVersion($composerFiles);
-
-        $this->cachedMinPhpVersion = $minPhpVersion;
-
-        $terminalCommand->setPhpVersion($minPhpVersion);
+        $terminalCommand->setPhpVersion($this->cachedMinPhpVersion);
 
         $event->getOutput()->writeln(
-            '<info>Targeted PHP version is ' . $minPhpVersion . '</info>' . PHP_EOL,
+            '<info>Targeted PHP version is ' . $this->cachedMinPhpVersion . '</info>' . PHP_EOL,
             OutputInterface::VERBOSITY_VERBOSE,
         );
     }

--- a/src/main/php/CommandLine/StaticCodeAnalysis/PHPStan/PHPStanConfigGenerator.php
+++ b/src/main/php/CommandLine/StaticCodeAnalysis/PHPStan/PHPStanConfigGenerator.php
@@ -26,6 +26,7 @@ class PHPStanConfigGenerator
             '/custom/plugins',
             '/custom/project',
             '/vendor',
+            '/vendor-bin',
         ];
 
     private string $phpStanConfigPath;
@@ -108,7 +109,7 @@ class PHPStanConfigGenerator
                 continue;
             }
             foreach ($functionsFiles as $functionsFile) {
-                $configValues['parameters']['bootstrapFiles'][] = $toolPath . $functionsFile;
+                $configValues['parameters']['scanFiles'][] = $toolPath . $functionsFile;
             }
         }
         return $configValues;

--- a/tests/System/Sniffs/Rdss/Standards/ZooRoyal/Sniffs/Safe/CheckSafeFunctionUsageSniffTest.php
+++ b/tests/System/Sniffs/Rdss/Standards/ZooRoyal/Sniffs/Safe/CheckSafeFunctionUsageSniffTest.php
@@ -35,7 +35,6 @@ class CheckSafeFunctionUsageSniffTest extends TestCase
     {
         $process = Process::fromShellCommandline('docker info');
         $process->run();
-        $process->wait();
         if ($process->getExitCode() !== 0) {
             self::markTestSkipped('Docker is not running');
         }
@@ -52,7 +51,7 @@ class CheckSafeFunctionUsageSniffTest extends TestCase
             ['bash',  $realpath . '/run-coding-standard.sh', 'sca:sniff'],
             $installationPath
         );
-        $processCodingStandard->setTimeout(240);
+        $processCodingStandard->setTimeout(480);
         $processCodingStandard->setIdleTimeout(120);
         $processCodingStandard->run();
         $processCodingStandard->wait();

--- a/tests/System/fixtures/complete/composer-template.json
+++ b/tests/System/fixtures/complete/composer-template.json
@@ -3,11 +3,11 @@
   "require": {
     "php": "^8.1"
   },
-  "require-dev":  {
+  "require-dev": {
     "zooroyal/coding-standard-source": "@dev"
   },
-  "repositories":{
-    "localRepo":{
+  "repositories": {
+    "localRepo": {
       "type": "path",
       "url": "",
       "options": {
@@ -24,7 +24,14 @@
       "infection/extension-installer": true,
       "mindplay/composer-locator": true,
       "phpstan/extension-installer": true,
-      "dealerdirect/phpcodesniffer-composer-installer": true
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "bamarni/composer-bin-plugin": true
+    }
+  },
+  "extra": {
+    "bamarni-bin": {
+      "bin-links": true,
+      "forward-command": true
     }
   }
 }

--- a/tests/System/fixtures/eslint/composer-template.json
+++ b/tests/System/fixtures/eslint/composer-template.json
@@ -1,10 +1,10 @@
 {
   "version": "0.0.1",
-  "require-dev":  {
+  "require-dev": {
     "zooroyal/coding-standard-source": "@dev"
   },
-  "repositories":{
-    "localRepo":{
+  "repositories": {
+    "localRepo": {
       "type": "path",
       "url": "",
       "options": {
@@ -21,7 +21,8 @@
       "infection/extension-installer": true,
       "mindplay/composer-locator": true,
       "phpstan/extension-installer": true,
-      "dealerdirect/phpcodesniffer-composer-installer": true
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "bamarni/composer-bin-plugin": true
     }
   }
 }

--- a/tests/Unit/CommandLine/StaticCodeAnalysis/Generic/TerminalCommand/PhpVersion/VersionDecoratorTest.php
+++ b/tests/Unit/CommandLine/StaticCodeAnalysis/Generic/TerminalCommand/PhpVersion/VersionDecoratorTest.php
@@ -112,7 +112,7 @@ class VersionDecoratorTest extends TestCase
         $this->mockedOutput->expects()->writeln(
             '<info>Targeted PHP version is ' . $expectedVersion . '</info>' . PHP_EOL,
             OutputInterface::VERBOSITY_VERBOSE,
-        )->once();
+        )->twice();
 
         $this->subject->decorate($this->mockedEvent);
         $this->subject->decorate($this->mockedEvent);

--- a/tests/Unit/CommandLine/StaticCodeAnalysis/PHPStan/PHPStanConfigGeneratorTest.php
+++ b/tests/Unit/CommandLine/StaticCodeAnalysis/PHPStan/PHPStanConfigGeneratorTest.php
@@ -108,9 +108,10 @@ class PHPStanConfigGeneratorTest extends TestCase
         );
 
         $functionsMatcher = H::hasKeyValuePair(
-            'bootstrapFiles',
+            'scanFiles',
             H::hasItems(
                 $this->mockedVendorDirectory . '/hamcrest/hamcrest-php/hamcrest/Hamcrest.php',
+                $this->mockedVendorDirectory . '/sebastianknott/hamcrest-object-accessor/src/functions.php',
                 $this->mockedVendorDirectory . '/mockery/mockery/library/helpers.php'
             ),
         );
@@ -144,11 +145,12 @@ class PHPStanConfigGeneratorTest extends TestCase
      */
     private function prepareMockedFilesystem(): void
     {
-        $this->mockedFilesystem->shouldReceive('exists')->twice()
+        $this->mockedFilesystem->shouldReceive('exists')->times(3)
             ->with(
                 H::anyOf(
                     $this->mockedRootDirectory . '/custom/plugins',
-                    $this->mockedVendorDirectory . '/deployer/deployer'
+                    $this->mockedVendorDirectory . '/deployer/deployer',
+                    $this->mockedVendorDirectory . '-bin',
                 )
             )->andReturn(false);
 

--- a/tests/run-coding-standard.sh
+++ b/tests/run-coding-standard.sh
@@ -18,8 +18,8 @@ CONTAINER_ID=$(docker run --rm -d --name cs-container --entrypoint "/bin/sleep" 
 echo copy files into container
 docker cp "$(pwd)"/. cs-container:/app/
 
-echo save state in container
 if [ ! -z "$(git status -s)" ]; then
+  echo save state in container
   docker exec cs-container git add .
   docker exec cs-container git commit -m "Before coding standard"
 fi
@@ -27,18 +27,24 @@ fi
 echo execute coding-standard
 set +e
 
+#docker exec -it cs-container /bin/bash
 docker exec -t cs-container /coding-standard/src/bin/coding-standard $@
 CS_EXIT_CODE=$?
 
 set -e
 
-echo gather changed files
 CHANGED_FILES=$(docker exec cs-container git diff --name-only HEAD)
 if [ ! -z "$CHANGED_FILES" ]; then
+  echo gather changed files
   for FILENAME in $CHANGED_FILES; do
       echo Sync changes to $FILENAME
       docker cp cs-container:/app/"$FILENAME" "$(pwd)"/"$FILENAME"
   done
+fi
+
+if [ -d "/app/tmp" ]; then
+    echo copy back tmp folder
+    docker cp cs-container:/app/tmp "$(pwd)"
 fi
 
 exit $CS_EXIT_CODE

--- a/vendor-bin/php-parallel-lint/composer.json
+++ b/vendor-bin/php-parallel-lint/composer.json
@@ -1,0 +1,6 @@
+{
+  "require": {
+    "php-parallel-lint/php-parallel-lint": "^1.3.2",
+    "php-parallel-lint/php-console-highlighter": "^1.0"
+  }
+}

--- a/vendor-bin/phpcpd/composer.json
+++ b/vendor-bin/phpcpd/composer.json
@@ -1,0 +1,5 @@
+{
+  "require": {
+    "sebastian/phpcpd": "^6.0.3"
+  }
+}

--- a/vendor-bin/phpmd/composer.json
+++ b/vendor-bin/phpmd/composer.json
@@ -1,0 +1,5 @@
+{
+  "require": {
+    "phpmd/phpmd": "^2.13.0"
+  }
+}

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,0 +1,18 @@
+{
+  "require": {
+    "phpstan/extension-installer": "^1.2",
+    "phpstan/phpstan": "^1.10.13",
+    "phpstan/phpstan-doctrine": "^1.3.32",
+    "phpstan/phpstan-mockery": "^1.1.0",
+    "phpstan/phpstan-phpunit": "^1.3.3",
+    "phpstan/phpstan-symfony": "^1.2.20"
+  },
+  "config": {
+    "optimize-autoloader": true,
+    "sort-packages": true,
+    "process-timeout": 600,
+    "allow-plugins": {
+      "phpstan/extension-installer": true
+    }
+  }
+}


### PR DESCRIPTION
The isolation of the sca was hardened even further. This PR introduces [`bamarni/composer-bin-plugin`](https://github.com/bamarni/composer-bin-plugin) for isolation of PHPStan, phpmd, phpmd, parallel-lint. They are transfered into their own vendor-bin directories and connected to composer. For more details please read the [README](./README.md)