### PR TITLE
Do not allow mockery >= 1.6.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     "amphp/process": "^v1.1.4",
     "brianium/paratest": "^6.8.1",
     "infection/infection": ">=0.26.16",
-    "mockery/mockery": "^1.5.1",
+    "mockery/mockery": ">=1.5.1,<=1.6.2",
     "phpunit/phpunit": "^9.5.28",
     "roave/security-advisories": "dev-latest",
     "sebastianknott/hamcrest-object-accessor": "^3.0.0"

--- a/src/main/php/CommandLine/StaticCodeAnalysis/PHPStan/PHPStanConfigGenerator.php
+++ b/src/main/php/CommandLine/StaticCodeAnalysis/PHPStan/PHPStanConfigGenerator.php
@@ -72,7 +72,7 @@ class PHPStanConfigGenerator
      *
      * @param array<EnhancedFileInfo> $exclusionList
      *
-     * @return array<string,array<int|string,array<int,string>|string>>>
+     * @return array<string,mixed>
      */
     private function generateConfig(OutputInterface $output, array $exclusionList, string $phpVersion): array
     {


### PR DESCRIPTION
With mockery version 1.6.3 the location of the helper script changed to `src/helpers.php`.

- https://github.com/mockery/mockery/compare/1.6.2...1.6.3#diff-7827dcf8c28ba9d97397f03b4ca75c132540f5c377e253fbc47ef064a373ce73
- https://github.com/mockery/mockery/pull/1290

This is why the coding-standard currently fails with:

```text
Running PHPStan
Scanned file /app/vendor/mockery/mockery/library/helpers.php does not exist.
```

For now we do not use mockery version 1.6.3 to prevent this error, but we should find a better solution in the long run.

(I would also suggest not to get the dependencies dynamically for every coding-standard run in the CI, but instead use fixed versions of the dependencies. So that the coding-standard does not fail if any third-party library does something stupid :wink:)