### PR TITLE
removed useless rule

### DIFF
--- a/config/stylelint/.stylelintrc
+++ b/config/stylelint/.stylelintrc
@@ -40,6 +40,7 @@
     "scss/double-slash-comment-empty-line-before": "always",
     "scss/map-keys-quotes": "always",
     "scss/percent-placeholder-pattern": null,
+    "scss/dollar-variable-pattern": null,
     "function-url-quotes": null,
     "custom-property-pattern": null,
     "selector-class-pattern": null


### PR DESCRIPTION
scss/dollar-variable-pattern to null 
cuz we do stuff like this:
`$wf-caption-3-line-height--desktop`

current error:
`Expected variable to be kebab-case  scss/dollar-variable-pattern`