### PR TITLE
activate php82 sniffs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "nikic/php-parser": "^4.18",
     "php-di/php-di": "^7.0.1",
     "slevomat/coding-standard": "^8.10.0",
-    "squizlabs/php_codesniffer": "^3.7.2",
+    "squizlabs/php_codesniffer": "^3.9.0",
     "symfony/console": " ^6.2.8",
     "symfony/event-dispatcher": "^6.2.2",
     "symfony/filesystem": " ^6.2.0",

--- a/config/phpcs/ZooRoyal/ruleset.xml
+++ b/config/phpcs/ZooRoyal/ruleset.xml
@@ -177,7 +177,7 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn"/>
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
     <rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch"/>
-     <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration">
+    <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration">
         <properties>
             <property name="spacesCountAfterKeyword" value="0"/>
             <property name="spacesCountBeforeArrow" value="1"/>

--- a/config/phpcs/ZooRoyal/ruleset.xml
+++ b/config/phpcs/ZooRoyal/ruleset.xml
@@ -109,12 +109,13 @@
     <rule ref="PEAR.WhiteSpace.ScopeClosingBrace"/>
 
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
+    <rule ref="SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing"/>
     <rule ref="SlevomatCodingStandard.Attributes.DisallowAttributesJoining"/>
     <rule ref="SlevomatCodingStandard.Attributes.DisallowMultipleAttributesPerLine"/>
+    <rule ref="SlevomatCodingStandard.Attributes.RequireAttributeAfterDocComment"/>
     <rule ref="SlevomatCodingStandard.Classes.BackedEnumTypeSpacing"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassMemberSpacing"/>
-    <!--<rule ref="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion"/>-->
     <rule ref="SlevomatCodingStandard.Classes.ClassStructure">
         <properties>
             <property name="groups" type="array">
@@ -139,6 +140,7 @@
     </rule>
     <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
     <rule ref="SlevomatCodingStandard.Classes.PropertyDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion"/>
     <rule ref="SlevomatCodingStandard.Commenting.DeprecatedAnnotationDeclaration"/>
     <rule ref="SlevomatCodingStandard.Commenting.DisallowCommentAfterCode"/>
     <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
@@ -171,9 +173,10 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.NewWithParentheses"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullSafeObjectOperator"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn"/>
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
-    <!--<rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch"/>-->
+    <rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch"/>
      <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration">
         <properties>
             <property name="spacesCountAfterKeyword" value="0"/>
@@ -183,7 +186,7 @@
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.Functions.DisallowEmptyFunction"/>
-<!--    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/>-->
+    <!--<rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/>-->
     <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse"/>
     <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
     <rule ref="SlevomatCodingStandard.Functions.StaticClosure"/>
@@ -206,6 +209,7 @@
     <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>
     <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
+    <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
     <rule ref="SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax"/>
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <properties>
@@ -217,34 +221,17 @@
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
     <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
-    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
-        <properties>
-            <property name="enableMixedTypeHint" type="bool" value="false"/>
-            <property name="enableUnionTypeHint" type="bool" value="false"/>
-            <property name="enableIntersectionTypeHint" type="bool" value="false"/>
-            <property name="enableStandaloneNullTrueFalseTypeHints" type="bool" value="false"/>
-        </properties>
-    </rule>
-    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
-        <properties>
-            <property name="enableMixedTypeHint" type="bool" value="false"/>
-            <property name="enableUnionTypeHint" type="bool" value="false"/>
-            <property name="enableIntersectionTypeHint" type="bool" value="false"/>
-            <property name="enableStandaloneNullTrueFalseTypeHints" type="bool" value="false"/>
-        </properties>
-    </rule>
-    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
-        <properties>
-            <property name="enableStaticTypeHint" type="bool" value="false"/>
-            <property name="enableMixedTypeHint" type="bool" value="false"/>
-            <property name="enableUnionTypeHint" type="bool" value="false"/>
-            <property name="enableIntersectionTypeHint" type="bool" value="false"/>
-            <property name="enableIntersectionTypeHint" type="bool" value="false"/>
-            <property name="enableNeverTypeHint" type="bool" value="false"/>
-            <property name="enableStandaloneNullTrueFalseTypeHints" type="bool" value="false"/>
-        </properties>
-    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat">
+        <properties>
+            <property name="withSpaces" type="bool" value="false"/>
+            <property name="shortNullable" type="bool" value="true"/>
+            <property name="nullPosition" type="bool" value="last"/>
+        </properties>
+    </rule>
     <!--
         https://packagist.org/packages/bmitch/codor are planed for PHP > 7.0
 

--- a/src/main/php/CommandLine/FileSearch/FastCachedFileSearch.php
+++ b/src/main/php/CommandLine/FileSearch/FastCachedFileSearch.php
@@ -31,7 +31,7 @@ class FastCachedFileSearch implements FileSearchInterface
         $dir = $path->getPathname();
         $exclusionPaths = array_map(
             static fn(EnhancedFileInfo $exclusion) => $exclusion->getPathname(),
-            $exclusions
+            $exclusions,
         );
 
         $resultingPathnames = $this->doTheSearch($fileName, $dir, $exclusionPaths, $minDepth, $maxDepth, 0);
@@ -100,7 +100,7 @@ class FastCachedFileSearch implements FileSearchInterface
 
             unset(
                 $filenamesInDirectory[array_search('.', $filenamesInDirectory, true)],
-                $filenamesInDirectory[array_search('..', $filenamesInDirectory, true)]
+                $filenamesInDirectory[array_search('..', $filenamesInDirectory, true)],
             );
 
             $this->fileSystemCache[$dir] = $filenamesInDirectory;
@@ -148,7 +148,7 @@ class FastCachedFileSearch implements FileSearchInterface
                 $exclusions,
                 $minDepth,
                 $maxDepth,
-                $depthNow + 1
+                $depthNow + 1,
             );
 
             $result = [...$result, ...$subFolderResults];

--- a/src/main/php/CommandLine/StaticCodeAnalysis/Generic/TerminalCommand/PhpVersion/ComposerInterpreter.php
+++ b/src/main/php/CommandLine/StaticCodeAnalysis/Generic/TerminalCommand/PhpVersion/ComposerInterpreter.php
@@ -34,7 +34,7 @@ class ComposerInterpreter
         $composerConfig = json_decode(
             file_get_contents($composerFile->getRealPath()),
             associative: true,
-            flags: JSON_THROW_ON_ERROR
+            flags: JSON_THROW_ON_ERROR,
         );
 
         $phpVersionConstraint = $composerConfig['config']['platform']['php']

--- a/src/main/php/CommandLine/StaticCodeAnalysis/JSESLint/TerminalCommand.php
+++ b/src/main/php/CommandLine/StaticCodeAnalysis/JSESLint/TerminalCommand.php
@@ -57,7 +57,7 @@ class TerminalCommand extends AbstractTerminalCommand implements
             $this->buildTargetingString(),
             $this->buildVerbosityString(),
             $this->buildFixingString(),
-            $this->buildPrefixString()
+            $this->buildPrefixString(),
         );
 
         $this->command = $sprintfCommand;

--- a/src/main/php/CommandLine/StaticCodeAnalysis/JSStyleLint/TerminalCommand.php
+++ b/src/main/php/CommandLine/StaticCodeAnalysis/JSStyleLint/TerminalCommand.php
@@ -58,7 +58,7 @@ class TerminalCommand extends AbstractTerminalCommand implements
             $this->buildTargetingString(),
             $this->buildVerbosityString(),
             $this->buildFixingString(),
-            $this->buildPrefixString()
+            $this->buildPrefixString(),
         );
 
         $this->command = $sprintfCommand;

--- a/src/main/php/Sniffs/Rdss/Standards/ZooRoyal/Sniffs/Safe/CheckSafeFunctionUsageSniff.php
+++ b/src/main/php/Sniffs/Rdss/Standards/ZooRoyal/Sniffs/Safe/CheckSafeFunctionUsageSniff.php
@@ -32,7 +32,7 @@ class CheckSafeFunctionUsageSniff implements Sniff
         try {
             // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
             $filesUnfiltered = @scandir($path);
-        } catch (DirException $exception) {
+        } catch (DirException) {
             return;
         }
 
@@ -85,7 +85,7 @@ class CheckSafeFunctionUsageSniff implements Sniff
         if (!isset($this->functionNames)) {
             throw new AssertionException(
                 'No function names found! Did you forget to install thecodingmachine/Safe?',
-                1684240278
+                1684240278,
             );
         }
 
@@ -97,7 +97,7 @@ class CheckSafeFunctionUsageSniff implements Sniff
             $this->assertGlobalFunctionCall($phpcsFile, $stackPtr);
             $this->assertFunctionProvidedBySafe($tokens[$stackPtr]['content']);
             $this->assertFunctionUnused($phpcsFile, $functionName);
-        } catch (AssertionException $exception) {
+        } catch (AssertionException) {
             // If this is the case we found no Safe function. Continue...
             return;
         }
@@ -127,7 +127,7 @@ class CheckSafeFunctionUsageSniff implements Sniff
             in_array(
                 $phpcsFile->getTokens()[$previousPointer]['code'],
                 [T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_FUNCTION],
-                true
+                true,
             )
         ) {
             throw new AssertionException('Token is not a global function call!', 1684230171);
@@ -163,7 +163,7 @@ class CheckSafeFunctionUsageSniff implements Sniff
             'Function \'' . $functionName . '\' is not imported from Safe! Add \'' . $missingUseStatement
             . '\' to your uses.',
             $stackPtr,
-            'FunctionNotImported'
+            'FunctionNotImported',
         );
     }
 }

--- a/tests/Functional/CommandLine/FileSearch/FastCachedFileSearchTest.php
+++ b/tests/Functional/CommandLine/FileSearch/FastCachedFileSearchTest.php
@@ -50,8 +50,8 @@ class FastCachedFileSearchTest extends TestCase
                     'tests/Functional/Sniffs/Rdss/Standards/ZooRoyal/Sniffs/TypeHints/Fixtures/ReturnType/.dontSniffPHP',
                     'tests/Functional/Sniffs/Rdss/Standards/ZooRoyal/Sniffs/Safe/fixtures/.dontSniffPHP',
                     'tests/System/fixtures/complete/.dontSniffPHP',
-                ])
-            )
+                ]),
+            ),
         );
     }
 
@@ -79,9 +79,9 @@ class FastCachedFileSearchTest extends TestCase
                         'tests/Functional/Sniffs/Rdss/Standards/ZooRoyal/Sniffs/TypeHints/Fixtures/ReturnType/.dontSniffPHP',
                         'tests/Functional/Sniffs/Rdss/Standards/ZooRoyal/Sniffs/Safe/fixtures/.dontSniffPHP',
                         'tests/System/fixtures/complete/.dontSniffPHP',
-                    ])
-                )
-            )
+                    ]),
+                ),
+            ),
         );
     }
 
@@ -100,7 +100,7 @@ class FastCachedFileSearchTest extends TestCase
             Matchers::not(
                 Matchers::containsInAnyOrder([
                     'tests/System/fixtures/complete/.dontSniffPHP',
-                ])
+                ]),
             ),
         );
         MatcherAssert::assertThat(
@@ -111,7 +111,7 @@ class FastCachedFileSearchTest extends TestCase
                 'tests/Functional/Sniffs/Rdss/Standards/ZooRoyal/Sniffs/TypeHints/Fixtures/ReturnType/.dontSniffPHP',
                 'tests/Functional/Sniffs/Rdss/Standards/ZooRoyal/Sniffs/Safe/fixtures/.dontSniffPHP',
                 'src/main/php/Sniffs/PHPCodeSniffer/.dontSniffPHP',
-            )
+            ),
         );
     }
 
@@ -147,8 +147,8 @@ class FastCachedFileSearchTest extends TestCase
         MatcherAssert::assertThat(
             $result,
             Matchers::hasValue(
-                HasProperty::hasProperty('relativePathname', 'tests/System/fixtures/complete/.dontSniffPHP')
-            )
+                HasProperty::hasProperty('relativePathname', 'tests/System/fixtures/complete/.dontSniffPHP'),
+            ),
         );
     }
 
@@ -166,7 +166,7 @@ class FastCachedFileSearchTest extends TestCase
             $resultPaths,
             Matchers::containsInAnyOrder([
                 'tests/System/fixtures/complete/.dontSniffPHP',
-            ])
+            ]),
         );
         MatcherAssert::assertThat(
             $resultPaths,
@@ -177,8 +177,8 @@ class FastCachedFileSearchTest extends TestCase
                     'tests/Functional/Sniffs/Rdss/Standards/ZooRoyal/Sniffs/TypeHints/Fixtures/ReturnType/.dontSniffPHP',
                     'tests/Functional/Sniffs/Rdss/Standards/ZooRoyal/Sniffs/Safe/fixtures/.dontSniffPHP',
                     'src/main/php/Sniffs/PHPCodeSniffer/.dontSniffPHP',
-                )
-            )
+                ),
+            ),
         );
     }
 }

--- a/tests/System/Sniffs/Rdss/Standards/ZooRoyal/Sniffs/Safe/CheckSafeFunctionUsageSniffTest.php
+++ b/tests/System/Sniffs/Rdss/Standards/ZooRoyal/Sniffs/Safe/CheckSafeFunctionUsageSniffTest.php
@@ -43,13 +43,13 @@ class CheckSafeFunctionUsageSniffTest extends TestCase
 
         $this->filesystem->copy(
             __DIR__ . '/fixtures/GoodPhp.php',
-            $installationPath . '/src/GoodPhp.php'
+            $installationPath . '/src/GoodPhp.php',
         );
 
         $realpath = realpath(__DIR__ . '/../../../../../../../');
         $processCodingStandard = new Process(
             ['bash',  $realpath . '/run-coding-standard.sh', 'sca:sniff'],
-            $installationPath
+            $installationPath,
         );
         $processCodingStandard->setTimeout(480);
         $processCodingStandard->setIdleTimeout(120);

--- a/tests/System/Stylelint/RunStylelintWithConfigTest.php
+++ b/tests/System/Stylelint/RunStylelintWithConfigTest.php
@@ -77,7 +77,7 @@ class RunStylelintWithConfigTest extends AsyncTestCase
                 __DIR__ . '/../../../node_modules/.bin/stylelint',
                 '--config=' . __DIR__ . '/../../../config/stylelint/.stylelintrc',
                 __DIR__ . '/../fixtures/stylelint/GoodCode.scss',
-            ]
+            ],
         );
 
         yield $process->start();

--- a/tests/Tools/TestEnvironmentInstallation.php
+++ b/tests/Tools/TestEnvironmentInstallation.php
@@ -159,7 +159,7 @@ class TestEnvironmentInstallation
         if ($this->filesystem->exists($vendorBinSourceDirectory)) {
             $this->filesystem->mirror(
                 $vendorBinSourceDirectory,
-                $this->installationPath . '/vendor-bin'
+                $this->installationPath . '/vendor-bin',
             );
 
             (new Process(

--- a/tests/Unit/CommandLine/FileFinder/AdaptableFileFinderTest.php
+++ b/tests/Unit/CommandLine/FileFinder/AdaptableFileFinderTest.php
@@ -43,7 +43,7 @@ class AdaptableFileFinderTest extends TestCase
     {
         $mockedTargetBranchInput = 'blaaaa';
         $this->expectExceptionObject(
-            new InvalidArgumentException('Target ' . $mockedTargetBranchInput . ' is no valid commit-ish.', 1553766210)
+            new InvalidArgumentException('Target ' . $mockedTargetBranchInput . ' is no valid commit-ish.', 1553766210),
         );
         $this->subjectParameters[GitInputValidator::class]->shouldReceive('isCommitishValid')
             ->with($mockedTargetBranchInput)->andReturn(false);

--- a/tests/Unit/CommandLine/StaticCodeAnalysis/Generic/TerminalCommand/PhpVersion/ComposerInterpreterTest.php
+++ b/tests/Unit/CommandLine/StaticCodeAnalysis/Generic/TerminalCommand/PhpVersion/ComposerInterpreterTest.php
@@ -31,7 +31,7 @@ class ComposerInterpreterTest extends TestCase
         $this->subject = new ComposerInterpreter(
             $this->mockedEnvironment,
             $this->mockedEnhancedFileInfoFactory,
-            $this->mockedConstraintToVersionConverter
+            $this->mockedConstraintToVersionConverter,
         );
     }
 

--- a/tests/Unit/CommandLine/StaticCodeAnalysis/Generic/TerminalCommand/PhpVersion/MinimalVersionDecoratorTest.php
+++ b/tests/Unit/CommandLine/StaticCodeAnalysis/Generic/TerminalCommand/PhpVersion/MinimalVersionDecoratorTest.php
@@ -38,7 +38,7 @@ class MinimalVersionDecoratorTest extends TestCase
 
         $this->subject = new MinimalVersionDecorator(
             $this->mockedConstraintToVersionConverter,
-            $this->mockedComposerInterpreter
+            $this->mockedComposerInterpreter,
         );
     }
 
@@ -82,7 +82,7 @@ class MinimalVersionDecoratorTest extends TestCase
         $this->mockedTerminalCommand->expects()->setMinimalPhpVersion('7.4.33')->twice();
         $this->mockedOutput->expects()->writeln(
             '<info>Targeted minimal PHP version is 7.4.33</info>' . PHP_EOL,
-            OutputInterface::VERBOSITY_VERBOSE
+            OutputInterface::VERBOSITY_VERBOSE,
         )->twice();
 
         $this->subject->decorate($this->mockedEvent);

--- a/tests/Unit/CommandLine/StaticCodeAnalysis/JSStyleLint/TerminalCommandTest.php
+++ b/tests/Unit/CommandLine/StaticCodeAnalysis/JSStyleLint/TerminalCommandTest.php
@@ -112,11 +112,11 @@ class TerminalCommandTest extends TestCase
                         'excluded' => [
                             new EnhancedFileInfo(
                                 self::FORGED_ABSOLUTE_ROOT . '/a',
-                                self::FORGED_ABSOLUTE_ROOT
+                                self::FORGED_ABSOLUTE_ROOT,
                             ),
                             new EnhancedFileInfo(
                                 self::FORGED_ABSOLUTE_ROOT . '/b',
-                                self::FORGED_ABSOLUTE_ROOT
+                                self::FORGED_ABSOLUTE_ROOT,
                             ),
                         ],
                         'extensions' => ['qweasd', 'argh'],
@@ -124,11 +124,11 @@ class TerminalCommandTest extends TestCase
                         'targets' => [
                             new EnhancedFileInfo(
                                 self::FORGED_ABSOLUTE_ROOT . '/c',
-                                self::FORGED_ABSOLUTE_ROOT
+                                self::FORGED_ABSOLUTE_ROOT,
                             ),
                             new EnhancedFileInfo(
                                 self::FORGED_ABSOLUTE_ROOT . '/d',
-                                self::FORGED_ABSOLUTE_ROOT
+                                self::FORGED_ABSOLUTE_ROOT,
                             ),
                         ],
                         'verbosityLevel' => OutputInterface::VERBOSITY_QUIET,
@@ -155,11 +155,11 @@ class TerminalCommandTest extends TestCase
                         'excluded' => [
                             new EnhancedFileInfo(
                                 self::FORGED_ABSOLUTE_ROOT . '/a',
-                                self::FORGED_ABSOLUTE_ROOT
+                                self::FORGED_ABSOLUTE_ROOT,
                             ),
                             new EnhancedFileInfo(
                                 self::FORGED_ABSOLUTE_ROOT . '/b',
-                                self::FORGED_ABSOLUTE_ROOT
+                                self::FORGED_ABSOLUTE_ROOT,
                             ),
                         ],
                     ],
@@ -197,11 +197,11 @@ class TerminalCommandTest extends TestCase
                         'targets' => [
                             new EnhancedFileInfo(
                                 self::FORGED_ABSOLUTE_ROOT . '/c',
-                                self::FORGED_ABSOLUTE_ROOT
+                                self::FORGED_ABSOLUTE_ROOT,
                             ),
                             new EnhancedFileInfo(
                                 self::FORGED_ABSOLUTE_ROOT . '/d',
-                                self::FORGED_ABSOLUTE_ROOT
+                                self::FORGED_ABSOLUTE_ROOT,
                             ),
                         ],
                     ],

--- a/tests/Unit/CommandLine/StaticCodeAnalysis/PHPStan/PHPStanConfigGeneratorTest.php
+++ b/tests/Unit/CommandLine/StaticCodeAnalysis/PHPStan/PHPStanConfigGeneratorTest.php
@@ -49,7 +49,7 @@ class PHPStanConfigGeneratorTest extends TestCase
         $this->subject = new PHPStanConfigGenerator(
             $this->mockedFilesystem,
             $mockedEnvironment,
-            $this->mockedPhpVersionConverter
+            $this->mockedPhpVersionConverter,
         );
     }
 
@@ -112,7 +112,7 @@ class PHPStanConfigGeneratorTest extends TestCase
             H::hasItems(
                 $this->mockedVendorDirectory . '/hamcrest/hamcrest-php/hamcrest/Hamcrest.php',
                 $this->mockedVendorDirectory . '/sebastianknott/hamcrest-object-accessor/src/functions.php',
-                $this->mockedVendorDirectory . '/mockery/mockery/library/helpers.php'
+                $this->mockedVendorDirectory . '/mockery/mockery/library/helpers.php',
             ),
         );
 
@@ -151,7 +151,7 @@ class PHPStanConfigGeneratorTest extends TestCase
                     $this->mockedRootDirectory . '/custom/plugins',
                     $this->mockedVendorDirectory . '/deployer/deployer',
                     $this->mockedVendorDirectory . '-bin',
-                )
+                ),
             )->andReturn(false);
 
         $this->mockedFilesystem->shouldReceive('exists')->times(6)
@@ -162,8 +162,8 @@ class PHPStanConfigGeneratorTest extends TestCase
                     $this->mockedVendorDirectory,
                     $this->mockedVendorDirectory . '/hamcrest/hamcrest-php',
                     $this->mockedVendorDirectory . '/sebastianknott/hamcrest-object-accessor',
-                    $this->mockedVendorDirectory . '/mockery/mockery'
-                )
+                    $this->mockedVendorDirectory . '/mockery/mockery',
+                ),
             )->andReturn(true);
 
         $this->mockedFilesystem->shouldReceive('dumpFile')->once()
@@ -173,7 +173,7 @@ class PHPStanConfigGeneratorTest extends TestCase
                     $configuration = Neon::decode($parameter);
                     MatcherAssert::assertThat($configuration, $this->buildConfigMatcher());
                     return true;
-                })
+                }),
             );
     }
 }

--- a/tests/Unit/Sniffs/Rdss/Standards/ZooRoyal/Sniffs/Safe/CheckSafeFunctionUsageSniffTest.php
+++ b/tests/Unit/Sniffs/Rdss/Standards/ZooRoyal/Sniffs/Safe/CheckSafeFunctionUsageSniffTest.php
@@ -51,8 +51,8 @@ class CheckSafeFunctionUsageSniffTest extends TestCase
         $this->expectExceptionObject(
             new RuntimeException(
                 'No function names found! Did you forget to install thecodingmachine/Safe?',
-                1684240278
-            )
+                1684240278,
+            ),
         );
 
         $subject = new CheckSafeFunctionUsageSniff();


### PR DESCRIPTION
The changes will only apply to PHP 8 code only. The rules will not touch PHP 7.4 compatible code. If your composer.json states in `require->php` that your code ist 7.4 compatible the rules will not apply.

- Switch on sniffs
- Apply rules to coding-standard
- Update PHPCS composer package
