### PR TITLE
Add PHPCompatibility Sniff for php 7.4 Syntax checking

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,6 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[*.{yml,yaml,json,neon}]
+[*.{yml,yaml,neon}]
 indent_size = 2
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: 'Validate composer.json and composer.lock'
-        run: 'composer validate --strict'
+        run: 'composer validate'
 
       - name: 'Determine composer cache directory'
         id: 'determine-composer-cache-directory'
@@ -85,7 +85,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: 'Validate composer.json and composer.lock'
-        run: 'composer validate --strict'
+        run: 'composer validate'
 
       - name: 'Determine composer cache directory'
         id: 'determine-composer-cache-directory'

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     "nette/neon": "^3.3",
     "nikic/php-parser": "^4.18",
     "php-di/php-di": "^7.0.1",
+    "phpcompatibility/php-compatibility": "dev-develop#a8d67148fb990fbf5c2f6166d54bc91cc01fc655",
     "slevomat/coding-standard": "^8.10.0",
     "squizlabs/php_codesniffer": "^3.9.0",
     "symfony/console": " ^6.2.8",

--- a/config/phpcs/ZooRoyal/ruleset.xml
+++ b/config/phpcs/ZooRoyal/ruleset.xml
@@ -12,6 +12,8 @@
         <exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
     </rule>
 
+    <rule ref="PHPCompatibility"/>
+
     <!-- Custom Rule-->
     <rule ref="../../../src/main/php/Sniffs/PHPCodeSniffer/Standards/ZooRoyal"/>
     <rule ref="../../../src/main/php/Sniffs/Rdss/Standards/ZooRoyal"/>

--- a/src/main/php/CommandLine/StaticCodeAnalysis/PHPCodeSniffer/TerminalCommand.php
+++ b/src/main/php/CommandLine/StaticCodeAnalysis/PHPCodeSniffer/TerminalCommand.php
@@ -148,10 +148,13 @@ class TerminalCommand extends AbstractTerminalCommand implements
      */
     private function buildPhpVersionString(): string
     {
-        $template = ' --runtime-set php_version %d';
-        $phpVersion = $this->phpVersionConverter->convertSemVerToPhpString($this->minimalPhpVersion);
+        $template = ' --runtime-set php_version %1$d --runtime-set testVersion %2$s';
+        $phpVersionPhpStyle = $this->phpVersionConverter->convertSemVerToPhpString($this->minimalPhpVersion);
 
-        $result = sprintf($template, $phpVersion);
+        $phpVersionLevels = explode('.', $this->minimalPhpVersion);
+        $phpVersionWithoutPatchLevel = implode('.', [$phpVersionLevels[0], $phpVersionLevels[1]]);
+
+        $result = sprintf($template, $phpVersionPhpStyle, $phpVersionWithoutPatchLevel . '-');
 
         return $result;
     }

--- a/tests/System/fixtures/complete/composer-template.json
+++ b/tests/System/fixtures/complete/composer-template.json
@@ -1,37 +1,39 @@
 {
-  "version": "0.0.1",
-  "require": {
-    "php": "^8.1"
-  },
-  "require-dev": {
-    "zooroyal/coding-standard-source": "@dev"
-  },
-  "repositories": {
-    "localRepo": {
-      "type": "path",
-      "url": "",
-      "options": {
-        "symlink": false
-      }
-    }
-  },
-  "config": {
-    "optimize-autoloader": true,
-    "sort-packages": true,
-    "process-timeout": 600,
-    "allow-plugins": {
-      "ocramius/package-versions": true,
-      "infection/extension-installer": true,
-      "mindplay/composer-locator": true,
-      "phpstan/extension-installer": true,
-      "dealerdirect/phpcodesniffer-composer-installer": true,
-      "bamarni/composer-bin-plugin": true
-    }
-  },
-  "extra": {
-    "bamarni-bin": {
-      "bin-links": true,
-      "forward-command": true
-    }
-  }
+    "version": "0.0.1",
+    "require": {
+        "php": "^8.1"
+    },
+    "require-dev": {
+        "zooroyal/coding-standard-source": "@dev"
+    },
+    "repositories": {
+        "localRepo": {
+            "type": "path",
+            "url": "",
+            "options": {
+                "symlink": false
+            }
+        }
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "sort-packages": true,
+        "process-timeout": 600,
+        "allow-plugins": {
+            "ocramius/package-versions": true,
+            "infection/extension-installer": true,
+            "mindplay/composer-locator": true,
+            "phpstan/extension-installer": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "bamarni/composer-bin-plugin": true
+        }
+    },
+    "extra": {
+        "bamarni-bin": {
+            "bin-links": true,
+            "forward-command": true
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/tests/System/fixtures/eslint/composer-template.json
+++ b/tests/System/fixtures/eslint/composer-template.json
@@ -1,28 +1,30 @@
 {
-  "version": "0.0.1",
-  "require-dev": {
-    "zooroyal/coding-standard-source": "@dev"
-  },
-  "repositories": {
-    "localRepo": {
-      "type": "path",
-      "url": "",
-      "options": {
-        "symlink": false
-      }
-    }
-  },
-  "config": {
-    "optimize-autoloader": true,
-    "sort-packages": true,
-    "process-timeout": 600,
-    "allow-plugins": {
-      "ocramius/package-versions": true,
-      "infection/extension-installer": true,
-      "mindplay/composer-locator": true,
-      "phpstan/extension-installer": true,
-      "dealerdirect/phpcodesniffer-composer-installer": true,
-      "bamarni/composer-bin-plugin": true
-    }
-  }
+    "version": "0.0.1",
+    "require-dev": {
+        "zooroyal/coding-standard-source": "@dev"
+    },
+    "repositories": {
+        "localRepo": {
+            "type": "path",
+            "url": "",
+            "options": {
+                "symlink": false
+            }
+        }
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "sort-packages": true,
+        "process-timeout": 600,
+        "allow-plugins": {
+            "ocramius/package-versions": true,
+            "infection/extension-installer": true,
+            "mindplay/composer-locator": true,
+            "phpstan/extension-installer": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "bamarni/composer-bin-plugin": true
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/tests/Tools/TerminalCommandTestData.php
+++ b/tests/Tools/TerminalCommandTestData.php
@@ -22,7 +22,7 @@ class TerminalCommandTestData
     /** @var array<string>  */
     private array $extensions = [];
     private int $processes = 1;
-    private string $phpVersion = '7.4';
+    private string $phpVersion = '7.4.0';
 
     /**
      * TerminalCommandTestData constructor.

--- a/tests/Unit/CommandLine/StaticCodeAnalysis/PHPCodeSniffer/TerminalCommandTest.php
+++ b/tests/Unit/CommandLine/StaticCodeAnalysis/PHPCodeSniffer/TerminalCommandTest.php
@@ -77,7 +77,7 @@ class TerminalCommandTest extends TestCase
             );
 
         $this->mockedPhpVersionConverter->shouldReceive('convertSemVerToPhpString')
-            ->with('7.4')
+            ->with('7.4.0')
             ->andReturn(70400);
 
         $this->subject->addAllowedFileExtensions($data->getExtensions());
@@ -120,11 +120,12 @@ class TerminalCommandTest extends TestCase
                         'expectedCommand' => 'php ' . self::FORGED_ABSOLUTE_VENDOR
                             . '/bin/phpcbf -q --extensions=qweasd,argh --parallel=7 -p --standard='
                             . self::FORGED_PACKAGE_DIRECTORY
-                            . '/config/phpcs/ZooRoyal/ruleset.xml --ignore=a,b --runtime-set php_version 70400 c d',
+                            . '/config/phpcs/ZooRoyal/ruleset.xml --ignore=a,b --runtime-set php_version 70400 '
+                            . '--runtime-set testVersion 7.4- c d',
                         'excluded' => [$mockedEnhancedFileInfo1, $mockedEnhancedFileInfo1],
                         'extensions' => ['qweasd', 'argh'],
                         'fixingMode' => true,
-                        'phpVersion' => '7.4',
+                        'phpVersion' => '7.4.0',
                         'targets' => [
                             new EnhancedFileInfo(self::FORGED_ABSOLUTE_VENDOR . '/c', self::FORGED_ABSOLUTE_VENDOR),
                             new EnhancedFileInfo(self::FORGED_ABSOLUTE_VENDOR . '/d', self::FORGED_ABSOLUTE_VENDOR),
@@ -140,7 +141,7 @@ class TerminalCommandTest extends TestCase
                         'expectedCommand' => 'php ' . self::FORGED_ABSOLUTE_VENDOR
                             . '/bin/phpcs -s --parallel=1 -p --standard=' . self::FORGED_PACKAGE_DIRECTORY
                             . '/config/phpcs/ZooRoyal/ruleset.xml --runtime-set php_version 70400 '
-                            . self::FORGED_RELATIV_ROOT,
+                            . '--runtime-set testVersion 7.4- ' . self::FORGED_RELATIV_ROOT,
                     ],
                 ),
             ],
@@ -150,8 +151,8 @@ class TerminalCommandTest extends TestCase
                         'expectedCommand' => 'php ' . self::FORGED_ABSOLUTE_VENDOR
                             . '/bin/phpcs -s --parallel=1 -p --standard=' . self::FORGED_PACKAGE_DIRECTORY
                             . '/config/phpcs/ZooRoyal/ruleset.xml --runtime-set php_version 70400 '
-                            . self::FORGED_RELATIV_ROOT,
-                        'phpVersion' => '7.4',
+                            . '--runtime-set testVersion 7.4- ' . self::FORGED_RELATIV_ROOT,
+                        'phpVersion' => '7.4.0',
                     ],
                 ),
             ],
@@ -161,7 +162,7 @@ class TerminalCommandTest extends TestCase
                         'expectedCommand' => 'php ' . self::FORGED_ABSOLUTE_VENDOR
                             . '/bin/phpcs -s --parallel=1 -p --standard=' . self::FORGED_PACKAGE_DIRECTORY
                             . '/config/phpcs/ZooRoyal/ruleset.xml --ignore=a,b --runtime-set php_version 70400 '
-                            . self::FORGED_RELATIV_ROOT,
+                            . '--runtime-set testVersion 7.4- ' . self::FORGED_RELATIV_ROOT,
                         'excluded' => [$mockedEnhancedFileInfo2, $mockedEnhancedFileInfo2],
                     ],
                 ),
@@ -173,7 +174,7 @@ class TerminalCommandTest extends TestCase
                             . '/bin/phpcs -s --extensions=asdqwe,qweasd --parallel=1 -p --standard='
                             . self::FORGED_PACKAGE_DIRECTORY
                             . '/config/phpcs/ZooRoyal/ruleset.xml --runtime-set php_version 70400 '
-                            . self::FORGED_RELATIV_ROOT,
+                            . '--runtime-set testVersion 7.4- ' . self::FORGED_RELATIV_ROOT,
                         'extensions' => ['asdqwe', 'qweasd'],
                     ],
                 ),
@@ -184,7 +185,7 @@ class TerminalCommandTest extends TestCase
                         'expectedCommand' => 'php ' . self::FORGED_ABSOLUTE_VENDOR
                             . '/bin/phpcbf --parallel=1 -p --standard=' . self::FORGED_PACKAGE_DIRECTORY
                             . '/config/phpcs/ZooRoyal/ruleset.xml --runtime-set php_version 70400 '
-                            . self::FORGED_RELATIV_ROOT,
+                            . '--runtime-set testVersion 7.4- ' . self::FORGED_RELATIV_ROOT,
                         'fixingMode' => true,
                     ],
                 ),
@@ -194,7 +195,8 @@ class TerminalCommandTest extends TestCase
                     [
                         'expectedCommand' => 'php ' . self::FORGED_ABSOLUTE_VENDOR
                             . '/bin/phpcs -s --parallel=1 -p --standard=' . self::FORGED_PACKAGE_DIRECTORY
-                            . '/config/phpcs/ZooRoyal/ruleset.xml --runtime-set php_version 70400 c d',
+                            . '/config/phpcs/ZooRoyal/ruleset.xml --runtime-set php_version 70400 '
+                            . '--runtime-set testVersion 7.4- c d',
                         'targets' => [
                             new EnhancedFileInfo(self::FORGED_ABSOLUTE_VENDOR . '/c', self::FORGED_ABSOLUTE_VENDOR),
                             new EnhancedFileInfo(self::FORGED_ABSOLUTE_VENDOR . '/d', self::FORGED_ABSOLUTE_VENDOR),
@@ -208,7 +210,7 @@ class TerminalCommandTest extends TestCase
                         'expectedCommand' => 'php ' . self::FORGED_ABSOLUTE_VENDOR
                             . '/bin/phpcs -s -q --parallel=1 -p --standard=' . self::FORGED_PACKAGE_DIRECTORY
                             . '/config/phpcs/ZooRoyal/ruleset.xml --runtime-set php_version 70400 '
-                            . self::FORGED_RELATIV_ROOT,
+                            . '--runtime-set testVersion 7.4- ' . self::FORGED_RELATIV_ROOT,
                         'verbosityLevel' => OutputInterface::VERBOSITY_QUIET,
                     ],
                 ),
@@ -219,7 +221,7 @@ class TerminalCommandTest extends TestCase
                         'expectedCommand' => 'php ' . self::FORGED_ABSOLUTE_VENDOR
                             . '/bin/phpcs -s -v --parallel=1 -p --standard=' . self::FORGED_PACKAGE_DIRECTORY
                             . '/config/phpcs/ZooRoyal/ruleset.xml --runtime-set php_version 70400 '
-                            . self::FORGED_RELATIV_ROOT,
+                            . '--runtime-set testVersion 7.4- ' . self::FORGED_RELATIV_ROOT,
                         'verbosityLevel' => OutputInterface::VERBOSITY_VERBOSE,
                     ],
                 ),
@@ -230,7 +232,7 @@ class TerminalCommandTest extends TestCase
                         'expectedCommand' => 'php ' . self::FORGED_ABSOLUTE_VENDOR
                             . '/bin/phpcs -s -vv --parallel=1 -p --standard=' . self::FORGED_PACKAGE_DIRECTORY
                             . '/config/phpcs/ZooRoyal/ruleset.xml --runtime-set php_version 70400 '
-                            . self::FORGED_RELATIV_ROOT,
+                            . '--runtime-set testVersion 7.4- ' . self::FORGED_RELATIV_ROOT,
                         'fixingMode' => false,
                         'verbosityLevel' => OutputInterface::VERBOSITY_VERY_VERBOSE,
                     ],
@@ -242,7 +244,7 @@ class TerminalCommandTest extends TestCase
                         'expectedCommand' => 'php ' . self::FORGED_ABSOLUTE_VENDOR
                             . '/bin/phpcs -s -vvv --parallel=1 -p --standard=' . self::FORGED_PACKAGE_DIRECTORY
                             . '/config/phpcs/ZooRoyal/ruleset.xml --runtime-set php_version 70400 '
-                            . self::FORGED_RELATIV_ROOT,
+                            . '--runtime-set testVersion 7.4- ' . self::FORGED_RELATIV_ROOT,
                         'verbosityLevel' => OutputInterface::VERBOSITY_DEBUG,
                     ],
                 ),
@@ -253,7 +255,7 @@ class TerminalCommandTest extends TestCase
                         'expectedCommand' => 'php ' . self::FORGED_ABSOLUTE_VENDOR
                             . '/bin/phpcs -s --parallel=28 -p --standard=' . self::FORGED_PACKAGE_DIRECTORY
                             . '/config/phpcs/ZooRoyal/ruleset.xml --runtime-set php_version 70400 '
-                            . self::FORGED_RELATIV_ROOT,
+                            . '--runtime-set testVersion 7.4- ' . self::FORGED_RELATIV_ROOT,
                         'processes' => 28,
                     ],
                 ),


### PR DESCRIPTION
We had to use "phpcompatibility/php-compatibility": "dev-develop#a8d67148fb990fbf5c2f6166d54bc91cc01fc655" because the required sniffs are not yet released. We pinned the version to a commit to avoid build problems by changes to dev-develop.