### PR TITLE
added 'part' to the list of defined tags

### DIFF
--- a/config/eslint/eslint.config.js
+++ b/config/eslint/eslint.config.js
@@ -59,6 +59,7 @@ module.exports = {
                             'widgetFieldIgnore',
                             'widgetFieldStore',
                             'widgetFieldHelpMessage',
+                            'part'
                         ],
                     }
                 ]


### PR DESCRIPTION
Explains eslint that the "part" tag is ok:

https://stenciljs.com/docs/styling#css-parts

`/**
 * Some Stencil Component
 *
 * @part test-part - Some test part.
 */
@Component({
    tag: 'vx-test-component,
    shadow: true,
})
export class VxTestComponent {...`